### PR TITLE
Fix regex action handling

### DIFF
--- a/code/bot.py
+++ b/code/bot.py
@@ -37,9 +37,11 @@ class JoinBot(discord.Bot):
         guild = member.guild
         quiz = self.quizconfig.config.get_quiz_by_guild(guild.id)
         if quiz and quiz.name_regex_actions:
-            for pattern, action in quiz.compiled_name_regex_actions:
+            for pattern, action_cfg in quiz.compiled_name_regex_actions:
                 if pattern.search(member.name) or pattern.search(member.display_name):
-                    logger.info(f'User {member.name} matched join regex {pattern.pattern}. Action {action.name}')
+                    logger.info(
+                        f'User {member.name} matched join regex {pattern.pattern}. Action {action_cfg.action.name}'
+                    )
                     await QuizLogger(quiz, guild).send_audit(
                         f'User {member.name} matched join regex {action_cfg.pattern}. Taking action {action_cfg.action.name}'
                     )

--- a/code/bot.py
+++ b/code/bot.py
@@ -43,7 +43,7 @@ class JoinBot(discord.Bot):
                         f'User {member.name} matched join regex {pattern.pattern}. Action {action_cfg.action.name}'
                     )
                     await QuizLogger(quiz, guild).send_audit(
-                        f'User {member.name} matched join regex {action_cfg.pattern}. Taking action {action_cfg.action.name}'
+                        f'User {member.name} matched join regex {pattern.pattern}. Taking action {action_cfg.action.name}'
                     )
                     if action_cfg.action == Action.KICK:
                         await guild.kick(member)

--- a/code/quiz_config.py
+++ b/code/quiz_config.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, Field
 from typing import Optional, List, Union
+import re
 from enum import Enum
 from hashlib import md5
 
@@ -62,6 +63,17 @@ class QuizConfig(BaseModel):
     def set_action_by_string(cls, v, *, values, **kwargs):
         if isinstance(v, str):
             return Action[v.upper()]
+
+    @property
+    def compiled_name_regex_actions(self):
+        compiled = []
+        for action in self.name_regex_actions:
+            try:
+                pattern = re.compile(action.pattern, re.IGNORECASE)
+            except re.error:
+                continue
+            compiled.append((pattern, action))
+        return compiled
 
 class QuizList(BaseModel):
     quizzes: List[QuizConfig]

--- a/code/quiz_config.py
+++ b/code/quiz_config.py
@@ -65,7 +65,7 @@ class QuizConfig(BaseModel):
         if isinstance(v, str):
             return Action[v.upper()]
 
-    @property
+    @cached_property
     def compiled_name_regex_actions(self):
         compiled = []
         for action in self.name_regex_actions:


### PR DESCRIPTION
## Summary
- handle regex pattern config in QuizConfig
- fix variable naming bug for regex actions in JoinBot

## Testing
- `python -m py_compile code/quiz_config.py code/bot.py code/quiz.py`


------
https://chatgpt.com/codex/tasks/task_e_685f753fcdbc832381668700211053cb